### PR TITLE
Support Buffer type for React Native

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
+        "buffer": "^6.0.3",
         "react-native-fs": "^2.20.0"
       },
       "devDependencies": {
@@ -4564,8 +4565,7 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/bl": {
       "version": "4.1.0",
@@ -4576,6 +4576,30 @@
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/brace-expansion": {
@@ -4650,9 +4674,9 @@
       }
     },
     "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "funding": [
         {
           "type": "github",
@@ -4667,10 +4691,9 @@
           "url": "https://feross.org/support"
         }
       ],
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -5788,8 +5811,7 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/image-size": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "*.d.ts"
   ],
   "dependencies": {
+    "buffer": "^6.0.3",
     "react-native-fs": "^2.20.0"
   },
   "devDependencies": {

--- a/tar-extractor.ts
+++ b/tar-extractor.ts
@@ -1,4 +1,5 @@
 import RNFS from 'react-native-fs';
+import { Buffer } from 'buffer';
 
 export class TarExtractor {
   blockSize = 512;


### PR DESCRIPTION
The `Buffer` type from Node.js is not available by default in React Native. React Native doesn't include Node.js libraries in its ecosystem, so we won't have direct access to the `Buffer` object.

However, we can use third-party libraries like [`buffer`](https://www.npmjs.com/package/buffer) to add `Buffer` support to your React Native project.