### PR TITLE
Make parsing of file names more robust

### DIFF
--- a/tar-extractor.ts
+++ b/tar-extractor.ts
@@ -58,7 +58,7 @@ export class TarExtractor {
   parseHeader(buffer: Buffer, paxHeaderData: Record<string, any>): TarFileHeader | null {
     const h = new TarFileHeader();
 
-    h.name = buffer.subarray(0, 100).toString('utf8').replace(/\0+$/, '');
+    h.name = this.__parseStr(buffer, 0, 100, true);
     this.__log('trace', `- file name '${h.name}' from `, buffer.subarray(0, 100));
     if (!h.name) {
         return null;
@@ -67,16 +67,16 @@ export class TarExtractor {
     // 8 bytes for mode
     // 8 bytes for uid
     // 8 bytes for gid
-    h.size = parseInt(buffer.subarray(124, 136).toString('utf8'), 8);
+    h.size = parseInt(this.__parseStr(buffer, 124, 136), 8);
     this.__log('trace', `- file size '${h.size}' from `, buffer.subarray(124, 136));
     // 12 bytes for mtime
     // 8 bytes for checksum
-    h.typeFlag = buffer.subarray(156, 157).toString('utf8');
+    h.typeFlag = this.__parseStr(buffer, 156, 157, true);
     this.__log('trace', `- file type '${h.typeFlag}' from `, buffer.subarray(156, 157));
     // 100 bytes for linkname
-    h.ustarIndicator = buffer.subarray(257, 263).toString('utf8');
+    h.ustarIndicator = this.__parseStr(buffer, 257, 263);
     this.__log('trace', `- ustar ind. '${h.ustarIndicator}' from `, buffer.subarray(257, 263));
-    h.prefix = buffer.subarray(345, 500).toString('utf8').replace(/\0+$/, '');
+    h.prefix = this.__parseStr(buffer, 345, 500, true);
     this.__log('trace', `- prefix '${h.prefix}' from `, buffer.subarray(345, 500));
     if (h.prefix) {
         h.name = `${h.prefix}/${h.name}`;
@@ -132,6 +132,11 @@ export class TarExtractor {
 
   setLogLevel(level: LogLevel): void {
     this.logLevel = level;
+  }
+
+  __parseStr(buffer: Buffer, start: number, end: number, trim?: boolean): string {
+    const s = buffer.toString('utf8', start, end);
+    return !trim ? s : s.replace(/\0+$/, '');
   }
 
   __log(level: LogLevel, ...args: any[]): void {

--- a/tar-extractor.ts
+++ b/tar-extractor.ts
@@ -57,6 +57,8 @@ export class TarExtractor {
     const h = new TarFileHeader();
 
     h.name = buffer.subarray(0, 100).toString('utf8').replace(/\0+$/, '');
+    // XXX: Remove this debug print later
+    this.__log(`parsed file name '${h.name}' from header block of size ${buffer.length}`);
     if (!h.name) {
         return null;
     }

--- a/tar-extractor.ts
+++ b/tar-extractor.ts
@@ -56,7 +56,7 @@ export class TarExtractor {
   parseHeader(buffer: Buffer, paxHeaderData: Record<string, any>): TarFileHeader | null {
     const h = new TarFileHeader();
 
-    h.name = buffer.subarray(0, 100).toString('utf8').replace(/\0/g, '');
+    h.name = buffer.subarray(0, 100).toString('utf8').replace(/\0+$/, '');
     if (!h.name) {
         return null;
     }
@@ -70,7 +70,7 @@ export class TarExtractor {
     h.typeFlag = buffer.subarray(156, 157).toString('utf8');
     // 100 bytes for linkname
     h.ustarIndicator = buffer.subarray(257, 263).toString('utf8');
-    h.prefix = buffer.subarray(345, 500).toString('utf8').replace(/\0/g, '');
+    h.prefix = buffer.subarray(345, 500).toString('utf8').replace(/\0+$/, '');
     if (h.prefix) {
         h.name = `${h.prefix}/${h.name}`;
     }

--- a/tar-extractor.ts
+++ b/tar-extractor.ts
@@ -56,7 +56,7 @@ export class TarExtractor {
   parseHeader(buffer: Buffer, paxHeaderData: Record<string, any>): TarFileHeader | null {
     const h = new TarFileHeader();
 
-    h.name = buffer.subarray(0, 100).toString().replace(/\0/g, '');
+    h.name = buffer.subarray(0, 100).toString('utf8').replace(/\0/g, '');
     if (!h.name) {
         return null;
     }
@@ -64,13 +64,13 @@ export class TarExtractor {
     // 8 bytes for mode
     // 8 bytes for uid
     // 8 bytes for gid
-    h.size = parseInt(buffer.subarray(124, 136).toString(), 8);
+    h.size = parseInt(buffer.subarray(124, 136).toString('utf8'), 8);
     // 12 bytes for mtime
     // 8 bytes for checksum
-    h.typeFlag = buffer.subarray(156, 157).toString();
+    h.typeFlag = buffer.subarray(156, 157).toString('utf8');
     // 100 bytes for linkname
-    h.ustarIndicator = buffer.subarray(257, 263).toString();
-    h.prefix = buffer.subarray(345, 500).toString().replace(/\0/g, '');
+    h.ustarIndicator = buffer.subarray(257, 263).toString('utf8');
+    h.prefix = buffer.subarray(345, 500).toString('utf8').replace(/\0/g, '');
     if (h.prefix) {
         h.name = `${h.prefix}/${h.name}`;
     }


### PR DESCRIPTION
Try to make the logic for parsing strings (and file names) from TAR headers more robust:
- explicitly set the encoding to UTF-8 (`utf8`)
- parse and slice using Buffer's `toString()` method; that is, pass it the offset to be printed
- trim 0 bytes only at the end of the string
- log the parsed file name