### PR TITLE
Seek to file offset crash fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",
-        "react-native-fs": "^2.20.0"
+        "react-native-fs": "github:PlanitarInc/react-native-fs#planitar/osergiienko/R1-1386-seekToFileOffset-crash-fix"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
@@ -10729,8 +10729,7 @@
     },
     "node_modules/react-native-fs": {
       "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/react-native-fs/-/react-native-fs-2.20.0.tgz",
-      "integrity": "sha512-VkTBzs7fIDUiy/XajOSNk0XazFE9l+QlMAce7lGuebZcag5CnjszB+u4BdqzwaQOdcYb5wsJIsqq4kxInIRpJQ==",
+      "resolved": "git+ssh://git@github.com/PlanitarInc/react-native-fs.git#2dea5468d4bbc8958c53971d473989be84e26098",
       "dependencies": {
         "base-64": "^0.1.0",
         "utf8": "^3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",
-        "react-native-fs": "github:PlanitarInc/react-native-fs#planitar/osergiienko/R1-1386-seekToFileOffset-crash-fix"
+        "react-native-fs": "github:PlanitarInc/react-native-fs#master"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
@@ -10728,8 +10728,8 @@
       }
     },
     "node_modules/react-native-fs": {
-      "version": "2.20.0",
-      "resolved": "git+ssh://git@github.com/PlanitarInc/react-native-fs.git#f4d696a97efc3a8eb0a3cf9eccb293e0b45c1a6e",
+      "version": "2.20.1",
+      "resolved": "git+ssh://git@github.com/PlanitarInc/react-native-fs.git#f768ee84d05b98f4286cb8d7d4dc726864a524a5",
       "dependencies": {
         "base-64": "^0.1.0",
         "utf8": "^3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10729,7 +10729,7 @@
     },
     "node_modules/react-native-fs": {
       "version": "2.20.0",
-      "resolved": "git+ssh://git@github.com/PlanitarInc/react-native-fs.git#2dea5468d4bbc8958c53971d473989be84e26098",
+      "resolved": "git+ssh://git@github.com/PlanitarInc/react-native-fs.git#f4d696a97efc3a8eb0a3cf9eccb293e0b45c1a6e",
       "dependencies": {
         "base-64": "^0.1.0",
         "utf8": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "buffer": "^6.0.3",
-    "react-native-fs": "^2.20.0"
+    "react-native-fs": "github:PlanitarInc/react-native-fs#planitar/osergiienko/R1-1386-seekToFileOffset-crash-fix"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@planitar/rnfs-untar",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Extract files from TAR archives in React Native environments",
   "main": "index.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "buffer": "^6.0.3",
-    "react-native-fs": "github:PlanitarInc/react-native-fs#planitar/osergiienko/R1-1386-seekToFileOffset-crash-fix"
+    "react-native-fs": "github:PlanitarInc/react-native-fs#master"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",


### PR DESCRIPTION
The crash was happening when tar file is more than 2 Gb of size.
It actually requires an RNFS type fixes and since original repo is not maintained we have created a fork with a fix.

Related:
 - https://github.com/PlanitarInc/react-native-fs/pull/1