### PR TITLE
Fixed NullPointer in Android reject method. [DA-2077]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10728,8 +10728,8 @@
       }
     },
     "node_modules/react-native-fs": {
-      "version": "2.20.1",
-      "resolved": "git+ssh://git@github.com/PlanitarInc/react-native-fs.git#f768ee84d05b98f4286cb8d7d4dc726864a524a5",
+      "version": "2.20.2",
+      "resolved": "git+ssh://git@github.com/PlanitarInc/react-native-fs.git#b4bab50c48a6537ce6d4000081922a6824dc66d2",
       "dependencies": {
         "base-64": "^0.1.0",
         "utf8": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@planitar/rnfs-untar",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Extract files from TAR archives in React Native environments",
   "main": "index.ts",
   "scripts": {


### PR DESCRIPTION
NullPointerException: Parameter specified as non-null is null: method com.facebook.react.bridge.PromiseImpl.reject, parameter code

Related:
 - https://planitar.atlassian.net/browse/DA-2077